### PR TITLE
Add .gitattributes to the project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+.git/		export-ignore
+tests/		export-ignore
+travis/		export-ignore
+.gitattributes	export-ignore
+.travis.yml	export-ignore
+phpunit.xml.*	export-ignore


### PR DESCRIPTION
This removes a lot of unnecessary junk from the exported file as well as from an installation via packagist/composer if we decide to add the extension to packagist.com.
